### PR TITLE
export hierarchical information between files and folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,28 +30,30 @@ new FsVisitor.Builder()
     .parallel()
     .visit(fsimageData, new FsVisitor() {
         @Override
-        public void onFile(FsImageProto.INodeSection.INode inode, String path) {
+        public void onFile(FsImageFile fsImageFile) {
             // Do something
-            String fileName = ("/".equals(path) ? path : path + '/') + inode.getName().toStringUtf8();
-            System.out.println(fileName);
-            FsImageProto.INodeSection.INodeFile f = inode.getFile();
-            PermissionStatus p = loader.getPermissionStatus(f.getPermission());
+            String absolutePath = fsImageFile.getPath();
+            System.out.println(absolutePath);
+            System.out.println(fsImageFile.getUser());
+            System.out.println(fsImageFile.getGroup())
+            System.out.println(fsImageFile.getPermission());
             ...
         }
              
         @Override
-        public void onDirectory(FsImageProto.INodeSection.INode inode, String path) {
+        public void onDirectory(FsImageDir fsImageDir) {
             // Do something
-            final String dirName = ("/".equals(path) ? path : path + '/') + inode.getName().toStringUtf8();
-            System.out.println("Directory : " + fileName);
-            
-            FsImageProto.INodeSection.INodeDirectory d = inode.getDirectory();
-            PermissionStatus p = loader.getPermissionStatus(d.getPermission());
+            String absolutePath = fsImageDir.getPath();
+            System.out.println("Directory : " + absolutePath);
+
+            System.out.println(fsImageDir.getUser());
+            System.out.println(fsImageDir.getGroup())
+            System.out.println(fsImageDir.getPermission());
             ...
         }
              
         @Override
-        public void onSymLink(FsImageProto.INodeSection.INode inode, String path) {
+        public void onSymLink(FsImageSymlink fsImageSymlink) {
             // Do something
         }
     }

--- a/lib/src/main/java/de/m3y/hadoop/hdfs/hfsa/core/FsImageData.java
+++ b/lib/src/main/java/de/m3y/hadoop/hdfs/hfsa/core/FsImageData.java
@@ -332,4 +332,14 @@ public class FsImageData {
         }
         return  pathWithoutDoubleSlashes;
     }
+
+    /**
+     * Gets the permission of a long value.
+     *
+     * @param permissionId the permission id of inode
+     * @return string representation of the permission.
+     */
+    public String getPermissionString(long permissionId) {
+        return FSImageFormatPBINode.Loader.loadPermission(permissionId, stringTable).getPermission().toString();
+    }
 }

--- a/lib/src/main/java/de/m3y/hadoop/hdfs/hfsa/core/FsImageDir.java
+++ b/lib/src/main/java/de/m3y/hadoop/hdfs/hfsa/core/FsImageDir.java
@@ -1,0 +1,42 @@
+package de.m3y.hadoop.hdfs.hfsa.core;
+
+public class FsImageDir extends FsImageInfo {
+  private long dataSpaceQuota;
+  private long nameSpaceQuota;
+
+  private long totalFileNum;  // total file num inside current folder
+
+  private long totalFileByte; // total file size inside current folder
+
+  public long getDataSpaceQuota() {
+    return dataSpaceQuota;
+  }
+
+  public void setDataSpaceQuota(long dataSpaceQuota) {
+    this.dataSpaceQuota = dataSpaceQuota;
+  }
+
+  public long getNameSpaceQuota() {
+    return nameSpaceQuota;
+  }
+
+  public void setNameSpaceQuota(long nameSpaceQuota) {
+    this.nameSpaceQuota = nameSpaceQuota;
+  }
+
+  public long getTotalFileNum() {
+    return totalFileNum;
+  }
+
+  public void setTotalFileNum(long totalFileNum) {
+    this.totalFileNum = totalFileNum;
+  }
+
+  public long getTotalFileByte() {
+    return totalFileByte;
+  }
+
+  public void setTotalFileByte(long totalFileByte) {
+    this.totalFileByte = totalFileByte;
+  }
+}

--- a/lib/src/main/java/de/m3y/hadoop/hdfs/hfsa/core/FsImageFile.java
+++ b/lib/src/main/java/de/m3y/hadoop/hdfs/hfsa/core/FsImageFile.java
@@ -1,0 +1,74 @@
+package de.m3y.hadoop.hdfs.hfsa.core;
+
+public class FsImageFile extends FsImageInfo {
+
+  private long accessTime;
+
+  private int replication;
+
+  private int blocksCount;
+
+  private long preferredBlockSize;
+
+  private int storagePolicyId;
+
+  private String blockType;
+
+  private long fileSizeByte;
+
+  public long getFileSizeByte() {
+    return fileSizeByte;
+  }
+
+  public void setFileSizeByte(long fileSizeByte) {
+    this.fileSizeByte = fileSizeByte;
+  }
+
+  public long getAccessTime() {
+    return accessTime;
+  }
+
+  public void setAccessTime(long accessTime) {
+    this.accessTime = accessTime;
+  }
+
+  public int getReplication() {
+    return replication;
+  }
+
+  public void setReplication(int replication) {
+    this.replication = replication;
+  }
+
+  public int getBlocksCount() {
+    return blocksCount;
+  }
+
+  public void setBlocksCount(int blocksCount) {
+    this.blocksCount = blocksCount;
+  }
+
+  public long getPreferredBlockSize() {
+    return preferredBlockSize;
+  }
+
+  public void setPreferredBlockSize(long preferredBlockSize) {
+    this.preferredBlockSize = preferredBlockSize;
+  }
+
+  public int getStoragePolicyId() {
+    return storagePolicyId;
+  }
+
+  public void setStoragePolicyId(int storagePolicyId) {
+    this.storagePolicyId = storagePolicyId;
+  }
+
+  public String getBlockType() {
+    return blockType;
+  }
+
+  public void setBlockType(String blockType) {
+    this.blockType = blockType;
+  }
+}

--- a/lib/src/main/java/de/m3y/hadoop/hdfs/hfsa/core/FsImageInfo.java
+++ b/lib/src/main/java/de/m3y/hadoop/hdfs/hfsa/core/FsImageInfo.java
@@ -1,0 +1,105 @@
+package de.m3y.hadoop.hdfs.hfsa.core;
+
+import org.apache.hadoop.hdfs.server.namenode.FsImageProto;
+
+public class FsImageInfo {
+  private Long fsImageId;
+  private Long inodeId;
+  private Long fatherInodeId;  // father folder inode id
+  private String path;
+  private String name;
+  private String user;
+  private String group;
+  private String permission;
+  private long modificationTime;
+  private FsImageProto.INodeSection.INode inode;
+  private long permissionId;
+
+  public long getPermissionId() {
+    return permissionId;
+  }
+
+  public void setPermissionId(long permissionId) {
+    this.permissionId = permissionId;
+  }
+
+  public FsImageProto.INodeSection.INode getInode() {
+    return inode;
+  }
+
+  public void setInode(FsImageProto.INodeSection.INode inode) {
+    this.inode = inode;
+  }
+
+  public Long getFsImageId() {
+    return fsImageId;
+  }
+
+  public void setFsImageId(Long fsImageId) {
+    this.fsImageId = fsImageId;
+  }
+
+  public Long getInodeId() {
+    return inodeId;
+  }
+
+  public void setInodeId(Long inodeId) {
+    this.inodeId = inodeId;
+  }
+
+  public Long getFatherInodeId() {
+    return fatherInodeId;
+  }
+
+  public void setFatherInodeId(Long fatherInodeId) {
+    this.fatherInodeId = fatherInodeId;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getUser() {
+    return user;
+  }
+
+  public void setUser(String user) {
+    this.user = user;
+  }
+
+  public String getGroup() {
+    return group;
+  }
+
+  public void setGroup(String group) {
+    this.group = group;
+  }
+
+  public String getPermission() {
+    return permission;
+  }
+
+  public void setPermission(String permission) {
+    this.permission = permission;
+  }
+
+  public long getModificationTime() {
+    return modificationTime;
+  }
+
+  public void setModificationTime(long modificationTime) {
+    this.modificationTime = modificationTime;
+  }
+}

--- a/lib/src/main/java/de/m3y/hadoop/hdfs/hfsa/core/FsImageLoader.java
+++ b/lib/src/main/java/de/m3y/hadoop/hdfs/hfsa/core/FsImageLoader.java
@@ -24,6 +24,7 @@ import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -73,7 +74,6 @@ public class FsImageLoader {
     public FsImageLoader(Builder.LoadingStrategy loadingStrategy) {
         this.loadingStrategy = loadingStrategy;
     }
-
     /**
      * Manages inodes.
      */

--- a/lib/src/main/java/de/m3y/hadoop/hdfs/hfsa/core/FsImageLoader.java
+++ b/lib/src/main/java/de/m3y/hadoop/hdfs/hfsa/core/FsImageLoader.java
@@ -24,7 +24,6 @@ import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.concurrent.atomic.LongAdder;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/lib/src/main/java/de/m3y/hadoop/hdfs/hfsa/core/FsImageSymLink.java
+++ b/lib/src/main/java/de/m3y/hadoop/hdfs/hfsa/core/FsImageSymLink.java
@@ -1,0 +1,34 @@
+package de.m3y.hadoop.hdfs.hfsa.core;
+
+import org.apache.hadoop.thirdparty.protobuf.ByteString;
+public class FsImageSymLink extends FsImageInfo {
+  private int serializedSize;
+
+  private ByteString target;
+
+  private long accessTime;
+
+  public int getSerializedSize() {
+    return serializedSize;
+  }
+
+  public void setSerializedSize(int serializedSize) {
+    this.serializedSize = serializedSize;
+  }
+
+  public ByteString getTarget() {
+    return target;
+  }
+
+  public void setTarget(ByteString target) {
+    this.target = target;
+  }
+
+  public long getAccessTime() {
+    return accessTime;
+  }
+
+  public void setAccessTime(long accessTime) {
+    this.accessTime = accessTime;
+  }
+}

--- a/lib/src/main/java/de/m3y/hadoop/hdfs/hfsa/util/FsUtil.java
+++ b/lib/src/main/java/de/m3y/hadoop/hdfs/hfsa/util/FsUtil.java
@@ -1,5 +1,8 @@
 package de.m3y.hadoop.hdfs.hfsa.util;
 
+import de.m3y.hadoop.hdfs.hfsa.core.FsImageDir;
+import de.m3y.hadoop.hdfs.hfsa.core.FsImageFile;
+import de.m3y.hadoop.hdfs.hfsa.core.FsImageSymLink;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.protocol.BlockStoragePolicy;
 import org.apache.hadoop.hdfs.protocol.proto.HdfsProtos;
@@ -97,4 +100,67 @@ public class FsUtil {
         }
         return size;
     }
+
+    /**
+     * Extracts the file information in an Inode
+     * @param inode the inode
+     * @return instance of FsImageFile if inode is a File else null
+     */
+    public static FsImageFile getFsImageFile(FsImageProto.INodeSection.INode inode) {
+        FsImageFile fsImageFile = new FsImageFile();
+        fsImageFile.setInode(inode);
+        FsImageProto.INodeSection.INodeFile file = inode.getFile();
+        fsImageFile.setAccessTime(file.getAccessTime());
+        fsImageFile.setBlocksCount(file.getBlocksCount());
+        fsImageFile.setReplication(file.getReplication());
+        fsImageFile.setBlockType(file.getBlockType().name());
+        fsImageFile.setPreferredBlockSize(file.getPreferredBlockSize());
+        fsImageFile.setStoragePolicyId(file.getStoragePolicyID());
+        fsImageFile.setModificationTime(file.getModificationTime());
+        fsImageFile.setInodeId(inode.getId());
+        fsImageFile.setName(inode.getName().toStringUtf8());
+        fsImageFile.setPermissionId(file.getPermission());
+        fsImageFile.setFileSizeByte(FsUtil.getFileSize(file));
+        // path, fatherInodeId, user, group, permission, fsImageId to be set
+        return fsImageFile;
+    }
+
+    /**
+     * Extracts the directory information in an Inode
+     * @param inode inode of directory
+     * @return an instance of FsImageDir
+     */
+    public static FsImageDir getFsImageDir(FsImageProto.INodeSection.INode inode) {
+        org.apache.hadoop.hdfs.server.namenode.FsImageProto.INodeSection.INodeDirectory iNodeDirectory = inode.getDirectory();
+        FsImageDir fsImageDir = new FsImageDir();
+        fsImageDir.setInode(inode);
+        fsImageDir.setName(inode.getName().toStringUtf8());
+        fsImageDir.setDataSpaceQuota(iNodeDirectory.getDsQuota());
+        fsImageDir.setNameSpaceQuota(iNodeDirectory.getNsQuota());
+        fsImageDir.setPermissionId(iNodeDirectory.getPermission());
+        fsImageDir.setModificationTime(iNodeDirectory.getModificationTime());
+        // path, fatherInodeId, user, group, permission, fsImageId, totalFileNum, totalFileByte to be set
+        return fsImageDir;
+    }
+
+    /**
+     * Extracts the symbol link information in an Inode
+     * @param inode inode of symbol link
+     * @return an instance of FsImageSynLink
+     */
+    public static FsImageSymLink getFsImageSymLink(FsImageProto.INodeSection.INode inode) {
+        FsImageProto.INodeSection.INodeSymlink inodeSymlink = inode.getSymlink();
+        FsImageSymLink fsImageSymLink = new FsImageSymLink();
+        fsImageSymLink.setInode(inode);
+        fsImageSymLink.setTarget(inodeSymlink.getTarget());
+        fsImageSymLink.setSerializedSize(inodeSymlink.getSerializedSize());
+        fsImageSymLink.setAccessTime(inodeSymlink.getAccessTime());
+        fsImageSymLink.setInodeId(inode.getId());
+        fsImageSymLink.setPermissionId(inodeSymlink.getPermission());
+        fsImageSymLink.setModificationTime(inodeSymlink.getModificationTime());
+        fsImageSymLink.setName(inode.getName().toStringUtf8());
+        // path, fatherInodeId,user, group, permission, fsImageId
+        return fsImageSymLink;
+    }
+
 }

--- a/lib/src/test/java/de/m3y/hadoop/hdfs/hfsa/core/FSImageLoaderMicroBenchmarkIT.java
+++ b/lib/src/test/java/de/m3y/hadoop/hdfs/hfsa/core/FSImageLoaderMicroBenchmarkIT.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.hadoop.hdfs.server.namenode.FsImageProto;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
@@ -94,18 +93,18 @@ public class FSImageLoaderMicroBenchmarkIT {
         }
 
         @Override
-        public void onFile(FsImageProto.INodeSection.INode inode, String path) {
-            blackhole.consume(inode);
+        public void onFile(FsImageFile fsImageFile) {
+            blackhole.consume(fsImageFile.getInode());
         }
 
         @Override
-        public void onDirectory(FsImageProto.INodeSection.INode inode, String path) {
-            blackhole.consume(inode);
+        public void onDirectory(FsImageDir fsImageDir) {
+            blackhole.consume(fsImageDir.getInode());
         }
 
         @Override
-        public void onSymLink(FsImageProto.INodeSection.INode inode, String path) {
-            blackhole.consume(inode);
+        public void onSymLink(FsImageSymLink fsImageSymLink) {
+            blackhole.consume(fsImageSymLink.getInode());
         }
     }
 

--- a/tool/src/main/java/de/m3y/hadoop/hdfs/hfsa/tool/SmallFilesReportCommand.java
+++ b/tool/src/main/java/de/m3y/hadoop/hdfs/hfsa/tool/SmallFilesReportCommand.java
@@ -11,12 +11,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import de.m3y.hadoop.hdfs.hfsa.core.FsImageData;
-import de.m3y.hadoop.hdfs.hfsa.core.FsVisitor;
-import de.m3y.hadoop.hdfs.hfsa.util.FsUtil;
+import de.m3y.hadoop.hdfs.hfsa.core.*;
 import de.m3y.hadoop.hdfs.hfsa.util.IECBinary;
-import org.apache.hadoop.fs.permission.PermissionStatus;
-import org.apache.hadoop.hdfs.server.namenode.FsImageProto;
 import picocli.CommandLine;
 
 /**
@@ -245,25 +241,25 @@ public class SmallFilesReportCommand extends AbstractReportCommand {
         try {
             FsVisitor visitor = new FsVisitor() {
                 @Override
-                public void onFile(FsImageProto.INodeSection.INode inode, String path) {
-                    FsImageProto.INodeSection.INodeFile f = inode.getFile();
-                    final long fileSizeBytes = FsUtil.getFileSize(f);
+                public void onFile(FsImageFile fsImageFile) {
+                    final long fileSizeBytes = fsImageFile.getFileSizeByte();
+                    String user = fsImageFile.getUser();
+                    String path = fsImageFile.getPath();
                     if (fileSizeBytes < fileSizeLimitBytes) {
-                        PermissionStatus p = fsImageData.getPermissionStatus(f.getPermission());
-                        if (userNameFilter.test(p.getUserName())) {
-                            report.getOrCreateUserReport(p.getUserName()).increment(path);
+                        if (userNameFilter.test(user)) {
+                            report.getOrCreateUserReport(user).increment(path);
                         }
                         report.increment(path);
                     }
                 }
 
                 @Override
-                public void onDirectory(FsImageProto.INodeSection.INode inode, String path) {
+                public void onDirectory(FsImageDir fsImageDir) {
                     // Not needed
                 }
 
                 @Override
-                public void onSymLink(FsImageProto.INodeSection.INode inode, String path) {
+                public void onSymLink(FsImageSymLink fsImageSymLink) {
                     // Not needed
                 }
             };

--- a/tool/src/main/java/de/m3y/hadoop/hdfs/hfsa/tool/UserUsageReportCommand.java
+++ b/tool/src/main/java/de/m3y/hadoop/hdfs/hfsa/tool/UserUsageReportCommand.java
@@ -12,12 +12,8 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import de.m3y.hadoop.hdfs.hfsa.core.FsImageData;
-import de.m3y.hadoop.hdfs.hfsa.core.FsVisitor;
-import de.m3y.hadoop.hdfs.hfsa.util.FsUtil;
+import de.m3y.hadoop.hdfs.hfsa.core.*;
 import de.m3y.hadoop.hdfs.hfsa.util.IECBinary;
-import org.apache.hadoop.fs.permission.PermissionStatus;
-import org.apache.hadoop.hdfs.server.namenode.FsImageProto;
 import picocli.CommandLine;
 
 /**
@@ -167,24 +163,22 @@ public class UserUsageReportCommand extends AbstractReportCommand {
         try {
             FsVisitor visitor = new FsVisitor() {
                 @Override
-                public void onFile(FsImageProto.INodeSection.INode inode, String path) {
-                    FsImageProto.INodeSection.INodeFile f = inode.getFile();
-                    if (f.getModificationTime() < minAge) {
-                        PermissionStatus p = fsImageData.getPermissionStatus(f.getPermission());
-                        if (user.equalsIgnoreCase(p.getUserName())) {
-                            final long fileSizeBytes = FsUtil.getFileSize(f);
-                            report.increment(path, fileSizeBytes);
+                public void onFile(FsImageFile fsImageFile) {
+                    if (fsImageFile.getModificationTime() < minAge) {
+                        if (user.equalsIgnoreCase(fsImageFile.getUser())) {
+                            final long fileSizeBytes = fsImageFile.getFileSizeByte();
+                            report.increment(fsImageFile.getPath(), fileSizeBytes);
                         }
                     }
                 }
 
                 @Override
-                public void onDirectory(FsImageProto.INodeSection.INode inode, String path) {
+                public void onDirectory(FsImageDir fsImageDir) {
                     // Not needed
                 }
 
                 @Override
-                public void onSymLink(FsImageProto.INodeSection.INode inode, String path) {
+                public void onSymLink(FsImageSymLink fsImageSymLink) {
                     // Not needed
                 }
             };


### PR DESCRIPTION
Hi, thank you for making this project available.

we are aiming to analyzing the entire name space of  a hadoop cluster and storing them in an OLAP databases .
so we need to know one file should locate within which folder.
to achieve this, I add the father inode id property to each inode object, which is `FsImageInfo.getFatherInodeId()` shown in the code.

meanwhile, I map the file, director and symlink inode to `FsImageFile`, `FsImageDir` and `FsImageSymLink` entities, respectively. These three entities are all derived from `FsImageInfo`. 

let me know if you have any suggestions.
thanks.


